### PR TITLE
Add Optional HTTP/1.0 Support

### DIFF
--- a/plugins/haproxy/haproxy.go
+++ b/plugins/haproxy/haproxy.go
@@ -163,6 +163,12 @@ func loadPluginConfig() (*PluginConfig, error) {
 		cfg.SSLOpts = sslOpts
 	}
 
+
+	defaultBackend := os.Getenv("HAPROXY_DEFAULT_BACKEND")
+	if defaultBackend != "" {
+		cfg.DefaultBackend = defaultBackend
+	}
+
 	return cfg, nil
 }
 

--- a/plugins/haproxy/pluginconfig.go
+++ b/plugins/haproxy/pluginconfig.go
@@ -15,4 +15,5 @@ type PluginConfig struct {
 	SSLCert                     string `json:"ssl_cert,omitempty"`
 	SSLPort                     int    `json:"ssl_port,omitempty"`
 	SSLOpts                     string `json:"ssl_opts,omitempty"`
+	DefaultBackend              string `json:"default_backend,omitempty"`
 }

--- a/plugins/haproxy/readme.md
+++ b/plugins/haproxy/readme.md
@@ -27,6 +27,7 @@ The following configuration is available through environment variables:
 - `HAPROXY_SSL_PORT`: HAProxy SSL port (default: `443`)
 - `HAPROXY_SSL_CERT`: Path to SSL certificate for HAProxy
 - `HAPROXY_SSL_OPTS`: SSL options for HAProxy
+- `HAPROXY_DEFAULT_BACKEND`: Backend hostname to use when no Host header exists
 
 > Note: environment variables are optional.  There are sensible defaults provided.
 

--- a/plugins/haproxy/template.go
+++ b/plugins/haproxy/template.go
@@ -35,6 +35,8 @@ frontend http-default
     {{ range $host := .Hosts }}acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
     use_backend {{ $host.Name }} if is_{{ $host.Name }}
     {{ end }}
+    {{ if .PluginConfig.DefaultBackend }}use_backend {{ .PluginConfig.DefaultBa
+    {{ end }}
 {{ range $host := .Hosts }}backend {{ $host.Name }}
     http-response add-header X-Request-Start %Ts.%ms
     balance {{ $host.BalanceAlgorithm }}

--- a/plugins/haproxy/template.go
+++ b/plugins/haproxy/template.go
@@ -35,7 +35,7 @@ frontend http-default
     {{ range $host := .Hosts }}acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
     use_backend {{ $host.Name }} if is_{{ $host.Name }}
     {{ end }}
-    {{ if .PluginConfig.DefaultBackend }}use_backend {{ .PluginConfig.DefaultBa
+    {{ if .PluginConfig.DefaultBackend }}use_backend {{ .PluginConfig.DefaultBackend }}
     {{ end }}
 {{ range $host := .Hosts }}backend {{ $host.Name }}
     http-response add-header X-Request-Start %Ts.%ms


### PR DESCRIPTION
HTTP/1.0 Requests do not contain a Host header like HTTP/1.1 requests do. This causes HTTP/1.0 requests to be dropped by the current haproxy configuration generated by interlock. This patch adds an HAPROXY_DEFAULT_BACKEND environment variable that optionally enables a server of last resort for such queries.
